### PR TITLE
Remove keycloak dockerfile in favour of pulling image via docker-compose

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,1 +1,0 @@
-FROM quay.io/keycloak/keycloak:11.0.2


### PR DESCRIPTION
Was mutually dependent on [compose PR #16](https://github.com/dycons/compose/pull/16).
Since that PR is taking a while to merge in, dependency was solved in [commit 95fb59d7f28bd6e6afae29985bd8fb9530ddfef4](https://github.com/dycons/compose/commit/95fb59d7f28bd6e6afae29985bd8fb9530ddfef4) instead.